### PR TITLE
make sure document has id

### DIFF
--- a/src/SolrEngine.php
+++ b/src/SolrEngine.php
@@ -41,7 +41,16 @@ class SolrEngine extends Engine
         $updateQuery = $this->client->createUpdate();
 
         $models->each(function($model) use(&$updateQuery){
-            $document = $updateQuery->createDocument($model->toSearchableArray());
+
+            $searchableModel = $model->toSearchableArray();
+
+            // make sure there is and id in the array - otherwise we will create duplicates all the time
+            if (array_key_exists('id', $searchableModel)) {
+                $searchableModel['id'] = $model->getScoutKey();
+            }
+
+            $document = $updateQuery->createDocument($searchableModel);
+
             $updateQuery->addDocument($document);
         });
 

--- a/src/SolrEngine.php
+++ b/src/SolrEngine.php
@@ -104,7 +104,9 @@ class SolrEngine extends Engine
      */
     public function paginate(Builder $builder, $perPage, $page)
     {
-        return $this->performSearch($builder, $perPage,$page - 1);
+        $offset = ($page-1) * $perPage;
+
+        return $this->performSearch($builder, $perPage, $offset);
     }
 
     /**


### PR DESCRIPTION
When there is no id in the searchable array we create a lot of duplicates in the index